### PR TITLE
Added display property for triggered-hidden class

### DIFF
--- a/js/adapt-contrib-triggered.js
+++ b/js/adapt-contrib-triggered.js
@@ -1,6 +1,6 @@
 /*
 * adapt-contrib-triggered
-* License - http://github.com/adaptlearning/adapt_framework/LICENSE
+* License - http://github.com/adaptlearning/adapt_framework/blob/master/LICENSE
 * Maintainers - Daryl Hedley <darylhedley@hotmail.com>, Dan Gray (dan@sinensis.co.uk)
 */
 define(function(require) {

--- a/less/triggered.less
+++ b/less/triggered.less
@@ -33,4 +33,5 @@
 
 .triggered-hidden {
     visibility: hidden;
+    display: none;
 }


### PR DESCRIPTION
- if we use `display: none` to hide components (like - `adapt-contrib-text`, `adapt-contrib-graphic` etc.. ) then we could prevent unexpected completion triggered by inview plugin.
- updated license link