### PR TITLE
Changes spans to divs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-triggered",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-triggered",
   "issues": "https://github.com/adaptlearning/adapt-contrib-triggered/issues",

--- a/templates/triggered-hide-button.hbs
+++ b/templates/triggered-hide-button.hbs
@@ -1,6 +1,6 @@
 <button tabindex="0" class='base triggered-button-hide' data-triggered-id="{{_id}}" style="top:{{_triggered.hideButton._top}}; right:{{_triggered.hideButton._right}}; bottom:{{_triggered.hideButton._bottom}}; left:{{_triggered.hideButton._left}};">
     {{#if _triggered.hideButton.buttonText}}
-    <span class="triggered-button-text">{{{_triggered.hideButton.buttonText}}}</span>
+    <div class="triggered-button-text">{{{_triggered.hideButton.buttonText}}}</span>
     {{else}}
     <span class='icon icon-cross'></span>
     {{/if}}

--- a/templates/triggered-hide-button.hbs
+++ b/templates/triggered-hide-button.hbs
@@ -1,6 +1,6 @@
 <button tabindex="0" class='base triggered-button-hide' data-triggered-id="{{_id}}" style="top:{{_triggered.hideButton._top}}; right:{{_triggered.hideButton._right}}; bottom:{{_triggered.hideButton._bottom}}; left:{{_triggered.hideButton._left}};">
     {{#if _triggered.hideButton.buttonText}}
-    <div class="triggered-button-text">{{{_triggered.hideButton.buttonText}}}</span>
+    <div class="triggered-button-text">{{{_triggered.hideButton.buttonText}}}</div>
     {{else}}
     <span class='icon icon-cross'></span>
     {{/if}}

--- a/templates/triggered-show-button.hbs
+++ b/templates/triggered-show-button.hbs
@@ -1,5 +1,5 @@
 {{#if _triggered.showButton.buttonText}}
-<div class="triggered-button-text">{{{_triggered.showButton.buttonText}}}</span>
+<span class="triggered-button-text">{{{_triggered.showButton.buttonText}}}</span>
 {{else}}
 <span class="icon icon-plus"></span>
 {{/if}}

--- a/templates/triggered-show-button.hbs
+++ b/templates/triggered-show-button.hbs
@@ -1,5 +1,5 @@
 {{#if _triggered.showButton.buttonText}}
-<span class="triggered-button-text">{{{_triggered.showButton.buttonText}}}</span>
+<div class="triggered-button-text">{{{_triggered.showButton.buttonText}}}</span>
 {{else}}
 <span class="icon icon-plus"></span>
 {{/if}}

--- a/templates/triggered-show-button.hbs
+++ b/templates/triggered-show-button.hbs
@@ -1,5 +1,5 @@
 {{#if _triggered.showButton.buttonText}}
-<span class="triggered-button-text">{{{_triggered.showButton.buttonText}}}</span>
+<div class="triggered-button-text">{{{_triggered.showButton.buttonText}}}</div>
 {{else}}
 <span class="icon icon-plus"></span>
 {{/if}}


### PR DESCRIPTION
Because `span` tags use `display: inline-block` rather than `display: block` if text goes over one line it doesn't display very well. Makes more sense to be a div instead. Before and after below.

<img width="347" alt="screen shot 2017-11-20 at 16 09 52" src="https://user-images.githubusercontent.com/1676635/33028240-4ce7dff4-ce0d-11e7-9d3b-1f98c69dcdd9.png">

<img width="365" alt="screen shot 2017-11-20 at 16 10 06" src="https://user-images.githubusercontent.com/1676635/33028243-4f024482-ce0d-11e7-84ff-8f2e557ae3c6.png">
