### PR TITLE
issue/2799 Removed redundant behaviour

### DIFF
--- a/js/triggeredView.js
+++ b/js/triggeredView.js
@@ -1,3 +1,4 @@
+import a11y from 'core/js/a11y';
 import Adapt from 'coreJS/adapt';
 
 export default class TriggeredView extends Backbone.View {
@@ -45,7 +46,7 @@ export default class TriggeredView extends Backbone.View {
       .removeClass('u-display-none');
     this.triggeredView.$el.data('inview', false);
     $(window).scroll();
-    Adapt.a11y.focusFirst(this.$el, { defer: true });
+    a11y.focusFirst(this.$el, { defer: true });
   }
 
   hide(event) {
@@ -58,6 +59,6 @@ export default class TriggeredView extends Backbone.View {
     $container.addClass('triggered__hidden');
     $(`.triggered__button-show[data-triggered-id='${currentTriggeredId}']`)
       .removeClass('u-display-none');
-    Adapt.a11y.focusFirst(this.$el, { defer: true });
+    a11y.focusFirst(this.$el, { defer: true });
   }
 }


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Switched to components.register from Adapt.register
* Use `a11y` directly